### PR TITLE
:sparkles: Setting up CI/CD Environment

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,37 @@
+name: SonarCloud
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'zulu' # Alternative distribution options are available
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonar --info

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -27,6 +27,7 @@ jobs:
           container port: 3306
           mysql database: 'new_morandi'
           mysql root password: 1234
+          mysql options: '--skip-ssl' # SSL 비활성화
 
       - name: Create application-dev.yml from GitHub Secret
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -18,6 +19,19 @@ jobs:
         with:
           java-version: 17
           distribution: 'zulu' # Alternative distribution options are available
+
+      - name: Start MySQL container
+        uses: mirromutth/mysql-action@v1.1
+        with:
+          host port: 3306
+          container port: 3306
+          mysql database: 'new_morandi'
+          mysql root password: 1234
+
+      - name: Create application-dev.yml from GitHub Secret
+        run: |
+          echo "${{ secrets.TEST_APPLICATION_YML }}" > src/main/resources/application.yml
+
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Create application-dev.yml from GitHub Secret
         run: |
+          mkdir -p src/main/resources
           echo "${{ secrets.TEST_APPLICATION_YML }}" > src/main/resources/application.yml
 
       - name: Cache SonarCloud packages

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,17 @@ plugins {
     id 'org.springframework.boot' version '3.2.2'
     id 'io.spring.dependency-management' version '1.1.4'
 }
+plugins {
+    id "org.sonarqube" version "4.4.1.3373"
+}
+
+sonar {
+    properties {
+        property "sonar.projectKey", "SWM-Morandi_NewMorandi-Backend"
+        property "sonar.organization", "swm-morandi"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
+}
 
 group = 'kr.co.morandi'
 version = '0.0.1-SNAPSHOT'


### PR DESCRIPTION
# 내용
#1 
## SonarCloud 연동
### 과정
- SONAR_TOKEN을 github secret에 추가
- sonarcloud의 build.gradle를 프로젝트에 추가
- build.yml을 ./github/workflows에 추가한다.

### 문제
GitHub Actions를 사용하여 CI/CD 파이프라인을 설정하는 과정에서 데이터베이스 연결 문제가 발생했습니다.

특히, 테스트 실행 중에 java.sql.SQLException: RSA public key is not available client side (option serverRsaPublicKeyFile not set) 오류 발생. 이 문제는 MariaDB JDBC 드라이버가 새로운 인증 방식인 caching_sha2_password를 사용할 때 일반적으로 발생함.

### 해결 방법
**방법 1**
- MySQL 인증 방식 변경: mysql_native_password 인증 방식으로 전환하는 방법을 고려했으나, 추가적인 데이터베이스 설정 변경이 필요

**방법 2**
- JDBC URL에 RSA 공개 키 옵션 추가: 이 방법은 공개 키 파일을 관리하는 추가적인 작업이 필요

**방법 3** 
- SSL 비활성화: 보안상의 이유로 권장되지 않는 방법이지만, 테스트 환경에서 일시적으로 사용 가능하다고 판단

따라서 방법 3을 선택하여 해결하였습니다. 
application.yml 파일에서 MariaDB JDBC 연결 URL에 allowPublicKeyRetrieval=true와 useSSL=false 옵션을 추가하여 문제를 해결했습니다.
이렇게 하면 JDBC 드라이버가 서버의 RSA 공개 키를 요구하지 않고, SSL 연결도 비활성화됩니다.

```java
spring:
  profiles:
    active: TEST
  jpa:
    hibernate:
        ddl-auto: create

  datasource:
    driver-class-name: org.mariadb.jdbc.Driver
    url: jdbc:mariadb://127.0.0.1/new_morandi?allowPublicKeyRetrieval=true&useSSL=false
    username: root
    password: 1234
``` 


