### PR TITLE
오늘의 문제 추출 쿼리 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,15 +3,9 @@ plugins {
     id 'org.springframework.boot' version '3.2.2'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
-}
-plugins {
     id "org.sonarqube" version "4.4.1.3373"
-}
-
-plugins {
     id 'jacoco'
 }
-
 
 def jacocoDir = layout.buildDirectory.dir("reports/")
 def QDomains = []
@@ -92,9 +86,14 @@ dependencies {
     // Jsoup
     implementation 'org.jsoup:jsoup:1.16.1'
 
+    // h2
+    implementation 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    runtimeOnly 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-devtools'
+
     // Pusher java client
     implementation group: 'com.pusher', name: 'pusher-java-client', version: '2.4.4'
-
 
     // WebFlux (WebClient)
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/kr/co/morandi/backend/common/config/H2Config.java
+++ b/src/main/java/kr/co/morandi/backend/common/config/H2Config.java
@@ -1,0 +1,35 @@
+package kr.co.morandi.backend.common.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.h2.tools.Server;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.sql.SQLException;
+
+@Component
+@Profile("test")
+@RequiredArgsConstructor
+@Slf4j
+public class H2Config {
+
+    // '/h2-console' 시 webflux로 인해 localhost:9080으로 접속해서 DB 확인해야 함
+    private final H2Properties properties;
+    private Server webServer;
+
+    @EventListener
+    public void start(ContextRefreshedEvent event) throws SQLException {
+        log.info("h2 port : {}", properties.getPort());
+        this.webServer = Server.createWebServer("-webPort", properties.getPort(), "-tcpAllowOthers").start();
+    }
+
+    @EventListener
+    public void stop(ContextClosedEvent event){
+        this.webServer.stop();
+
+    }
+}

--- a/src/main/java/kr/co/morandi/backend/common/config/H2Properties.java
+++ b/src/main/java/kr/co/morandi/backend/common/config/H2Properties.java
@@ -1,0 +1,16 @@
+package kr.co.morandi.backend.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Getter
+@Setter
+@ConfigurationProperties("spring.h2.console")
+@Configuration
+@Profile("test")
+public class H2Properties {
+    private String port;
+}

--- a/src/main/java/kr/co/morandi/backend/defense_information/domain/model/defense/ProblemTier.java
+++ b/src/main/java/kr/co/morandi/backend/defense_information/domain/model/defense/ProblemTier.java
@@ -1,5 +1,7 @@
 package kr.co.morandi.backend.defense_information.domain.model.defense;
 
+import kr.co.morandi.backend.common.exception.MorandiException;
+import kr.co.morandi.backend.problem_information.domain.model.error.ProblemErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +25,7 @@ public enum ProblemTier {
 
     public static List<ProblemTier> tierRangeOf(ProblemTier start, ProblemTier end) {
         if (start.tier > end.tier)
-            throw new IllegalArgumentException("시작 티어가 끝 티어보다 높을 수 없습니다.");
+            throw new MorandiException(ProblemErrorCode.PROBLEM_TIER_ERROR);
 
         return VALUES.stream()
                 .filter(tier -> tier.tier >= start.tier && tier.tier <= end.tier)

--- a/src/main/java/kr/co/morandi/backend/defense_information/domain/service/dailydefense/DailyDefenseGenerationService.java
+++ b/src/main/java/kr/co/morandi/backend/defense_information/domain/service/dailydefense/DailyDefenseGenerationService.java
@@ -23,11 +23,11 @@ public class DailyDefenseGenerationService {
     private final DailyDefenseProblemPort dailyDefenseProblemPort;
     private final DailyDefensePort dailyDefensePort;
 
-    private static final Map.Entry<Long, RandomCriteria> PROBLEM_1 = getRandomCriteria(1L, B5, B1, 1000L, 300000L);
-    private static final Map.Entry<Long, RandomCriteria> PROBLEM_2 = getRandomCriteria(2L, S5, S4, 1000L, 300000L);
-    private static final Map.Entry<Long, RandomCriteria> PROBLEM_3 = getRandomCriteria(3L, S3, S1, 1000L, 300000L);
-    private static final Map.Entry<Long, RandomCriteria> PROBLEM_4 = getRandomCriteria(4L, G5, G4, 1000L, 300000L);
-    private static final Map.Entry<Long, RandomCriteria> PROBLEM_5 = getRandomCriteria(5L, G3, G1, 1000L, 300000L);
+    private static final Map.Entry<Long, RandomCriteria> PROBLEM_1 = getRandomCriteria(1L, B5, B1, 1000L, 30000L);
+    private static final Map.Entry<Long, RandomCriteria> PROBLEM_2 = getRandomCriteria(2L, S5, S4, 1000L, 30000L);
+    private static final Map.Entry<Long, RandomCriteria> PROBLEM_3 = getRandomCriteria(3L, S3, S1, 1000L, 30000L);
+    private static final Map.Entry<Long, RandomCriteria> PROBLEM_4 = getRandomCriteria(4L, G5, G4, 1000L, 30000L);
+    private static final Map.Entry<Long, RandomCriteria> PROBLEM_5 = getRandomCriteria(5L, G3, G1, 1000L, 30000L);
     private static final String POSTFIX = "%d월 %d일 오늘의 문제";
 
     @Transactional

--- a/src/main/java/kr/co/morandi/backend/defense_information/infrastructure/adapter/dailydefense/DailyDefenseProblemAdapter.java
+++ b/src/main/java/kr/co/morandi/backend/defense_information/infrastructure/adapter/dailydefense/DailyDefenseProblemAdapter.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -44,7 +45,7 @@ public class DailyDefenseProblemAdapter implements DailyDefenseProblemPort {
                                                             randomCriteria.getMinSolvedCount(),
                                                             randomCriteria.getMaxSolvedCount(), pageable);
 
-                    int randomNum = ThreadLocalRandom.current().nextInt(0, dailyDefenseProblems.size());
+                    int randomNum = new SecureRandom().nextInt(dailyDefenseProblems.size());
                     return Map.entry(entry.getKey(), dailyDefenseProblems.get(randomNum));
                 })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/src/main/java/kr/co/morandi/backend/defense_information/infrastructure/adapter/dailydefense/DailyDefenseProblemAdapter.java
+++ b/src/main/java/kr/co/morandi/backend/defense_information/infrastructure/adapter/dailydefense/DailyDefenseProblemAdapter.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 @Component
@@ -27,7 +28,8 @@ public class DailyDefenseProblemAdapter implements DailyDefenseProblemPort {
     @Override
     public Map<Long, Problem> getDailyDefenseProblem(Map<Long, RandomCriteria> criteria) {
 
-        Pageable pageable = PageRequest.of(0, 1);
+        Pageable pageable = PageRequest.of(0, 50);
+        Random random = new Random();
 
         return criteria.entrySet().stream()
                 .map(entry -> {
@@ -37,12 +39,12 @@ public class DailyDefenseProblemAdapter implements DailyDefenseProblemPort {
                     final ProblemTier endTier = difficultyRange.getEndDifficulty();
 
                     final List<Problem> dailyDefenseProblems =
-                            problemRepository.getDailyDefenseProblems(ProblemTier.tierRangeOf(startTier, endTier),
-                                                                        randomCriteria.getMinSolvedCount(),
-                                                                        randomCriteria.getMaxSolvedCount(),
-                                                                        pageable);
+                            problemRepository.getDailyDefenseProblems
+                                    (ProblemTier.tierRangeOf(startTier, endTier),
+                                                            randomCriteria.getMinSolvedCount(),
+                                                            randomCriteria.getMaxSolvedCount(), pageable);
 
-                    return Map.entry(entry.getKey(), dailyDefenseProblems.get(0));
+                    return Map.entry(entry.getKey(), dailyDefenseProblems.get(random.nextInt(dailyDefenseProblems.size())));
                 })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }

--- a/src/main/java/kr/co/morandi/backend/defense_information/infrastructure/adapter/dailydefense/DailyDefenseProblemAdapter.java
+++ b/src/main/java/kr/co/morandi/backend/defense_information/infrastructure/adapter/dailydefense/DailyDefenseProblemAdapter.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 @Component
@@ -29,7 +30,6 @@ public class DailyDefenseProblemAdapter implements DailyDefenseProblemPort {
     public Map<Long, Problem> getDailyDefenseProblem(Map<Long, RandomCriteria> criteria) {
 
         Pageable pageable = PageRequest.of(0, 50);
-        Random random = new Random();
 
         return criteria.entrySet().stream()
                 .map(entry -> {
@@ -44,7 +44,8 @@ public class DailyDefenseProblemAdapter implements DailyDefenseProblemPort {
                                                             randomCriteria.getMinSolvedCount(),
                                                             randomCriteria.getMaxSolvedCount(), pageable);
 
-                    return Map.entry(entry.getKey(), dailyDefenseProblems.get(random.nextInt(dailyDefenseProblems.size())));
+                    int randomNum = ThreadLocalRandom.current().nextInt(0, dailyDefenseProblems.size());
+                    return Map.entry(entry.getKey(), dailyDefenseProblems.get(randomNum));
                 })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }

--- a/src/main/java/kr/co/morandi/backend/problem_information/domain/model/error/ProblemErrorCode.java
+++ b/src/main/java/kr/co/morandi/backend/problem_information/domain/model/error/ProblemErrorCode.java
@@ -1,0 +1,23 @@
+package kr.co.morandi.backend.problem_information.domain.model.error;
+
+import kr.co.morandi.backend.common.exception.errorcode.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ProblemErrorCode implements ErrorCode {
+    PROBLEM_TIER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "시작 티어가 끝 티어보다 높을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/kr/co/morandi/backend/problem_information/domain/model/problem/Problem.java
+++ b/src/main/java/kr/co/morandi/backend/problem_information/domain/model/problem/Problem.java
@@ -9,7 +9,7 @@ import static kr.co.morandi.backend.problem_information.domain.model.problem.Pro
 
 @Entity
 @Table(name = "problem", indexes = {
-        @Index(name = "idx-", columnList = "solvedCount, problemTier, problemStatus")
+        @Index(name = "idx_problem_solvedCount_tier_status", columnList = "solvedCount, problemTier, problemStatus")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/kr/co/morandi/backend/problem_information/domain/model/problem/Problem.java
+++ b/src/main/java/kr/co/morandi/backend/problem_information/domain/model/problem/Problem.java
@@ -8,6 +8,9 @@ import lombok.*;
 import static kr.co.morandi.backend.problem_information.domain.model.problem.ProblemStatus.INIT;
 
 @Entity
+@Table(name = "problem", indexes = {
+        @Index(name = "idx-", columnList = "solvedCount, problemTier, problemStatus")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Problem extends BaseEntity {

--- a/src/main/java/kr/co/morandi/backend/problem_information/infrastructure/persistence/problem/ProblemRepository.java
+++ b/src/main/java/kr/co/morandi/backend/problem_information/infrastructure/persistence/problem/ProblemRepository.java
@@ -14,13 +14,12 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
     @Query("""
         SELECT p
         FROM Problem p
+        LEFT JOIN DailyDefenseProblem ddp ON p.problemId = ddp.problem.problemId
         WHERE p.problemStatus = 'ACTIVE'
-        AND p.problemTier IN :problemTiers
-        AND p.solvedCount >= :startSolvedCount
-        AND p.solvedCount <= :endSolvedCount
-        AND p NOT IN (SELECT ddp.problem
-                      FROM DailyDefenseProblem ddp)
-        ORDER BY FUNCTION('RAND')
+            AND p.problemTier IN :problemTiers
+            AND p.solvedCount >= :startSolvedCount
+            AND p.solvedCount <= :endSolvedCount
+            AND ddp.problem IS NULL
     """)
     List<Problem> getDailyDefenseProblems(List<ProblemTier> problemTiers, Long startSolvedCount, Long endSolvedCount, Pageable pageable);
 


### PR DESCRIPTION
- 이슈 번호
#47 

### Problem

사용자가 테스트를 시작할 때, 문제를 추출하는 과정에는 몇 가지 중요한 조건이 필요했다.

1) 백준 사이트에서 설정된 특정 정답자 수 범위에 속하는 문제를 추출해야 한다.
2) 백준 사이트 내 난이도 범위에 맞는 문제를 추출해야 한다.
3) '코딩테스트’ 형식의 경우 사용자가 풀지 않은 문제, ‘오늘의 문제’ 형식의 경우 과거에 출제되지 않는 문제를 추출해야 한다.
4) 정렬된 형태가 아닌 무작위로 문제를 추출해야 한다.

​대표적으로 ‘오늘의 문제’ 추출의 경우 5문제를 매일 추출해야 한다. 또한, 1번 문제의 경우 난이도 범위가 Bronze 5 ~ Bronze 1 이며, 2번 문제의 경우 난이도 범위가 Silver 5 ~ Silver 4 이며, 3번 문제의 경우 Silver 3 ~ Silver 1, 4번 문제의 경우 Gold 5 ~ Gold 4, 5번 문제의 경우 Gold 3 ~ Gold 1을 추출한다.

​추후, 난이도 범위가 변경될 것을 고려하여 이를 추출하는 동적 쿼리를 다음과 같이 구성하였다.

![image](https://github.com/user-attachments/assets/e2ffefbd-648d-43b9-9e8c-fc32f5298b74)

현재 Problem (문제) 테이블과 DailyDefenseProblem (출제된 오늘의 문제) 테이블은 일대다 매핑이 되어있다.

![image](https://github.com/user-attachments/assets/112d8e54-b442-4d63-b94b-fe0249e665a7)

또한, Where 문으로 Problem 테이블 내 활성화된 문제이면서, 문제 난이도 (Tier) 범위에 포함되면서, 정답자 수 범위에 포함되며, 오늘의 문제에 출제되지 않은 (NOT IN) 문제를 쿼리로 호출한 후 ORDER BY FUNCTION(’RAND’)를 통해 무작위로 한 문제를 추출하는 쿼리를 구성하였다.

![image](https://github.com/user-attachments/assets/8587d58c-74d4-46c3-acdd-197c16be807a)

해당 쿼리를 테스트 하기 위해 Problem 30000개를 구성하였고, 오늘의 문제로 출제된 문제는 15000개로 가정하였다. 각 문제의 난이도와 정답자 수는 무작위로 구성하였고 문제 1개를 추출하는데 쿼리 호출 시간을 알아본 결과 79ms가 발생하였다. 
만약, 오늘의 문제나 코딩테스트 문제를 위해 5문제를 추출한다면 대략 395ms가 호출되는 셈이다. 
이는 매우 비효율적이었다.

### How To

**1) NOT IN을 JOIN으로 변경**
서브쿼리 대신 JOIN 쿼리를 이용하고 오늘의 문제가 NULL인 Problem 들을 가져오는 쿼리로 변경하였다.
NOT IN 접근법은 내부적으로 전체 결과를 계산한 후에 외부 쿼리와 비교하는 방식이다.
기본적으로 해당 서비스에서는 1만개 이상의 서브쿼리 데이터가 쌓일 수 있으므로 성능 저하의 주된 원인이 될수 있다. 
반면에 JOIN은 NOT IN 쿼리에 비해 연관관계를 기반으로 빠르게 관련 데이터를 찾아낼 수 있다.

![image](https://github.com/user-attachments/assets/6a90cb36-bbe1-43e8-a4e4-b1ae606cc131)

**2) WHERE 절 최적화를 위한 인덱싱 적용**
WHERE 절을 수행할 때 푼 사람 수, 난이도 범위, 활성화 여부를 모두 조건이 걸려있어 성능적으로 좋지 못하였다. 성능 문제를 해결하기 위해 데이터베이스 인덱싱 전략을 세밀하게 조정하였다. 주요 쿼리에서 '푼 사람 수', '난이도 범위', 그리고 '활성화 여부'를 기준으로 데이터를 필터링해야 했는데, 이 조건들의 카디널리티를 분석한 결과, 다음과 같은 인덱싱 전략을 수립하게 되었다.

1) 푼 사람 수: 0명에서 10만 명까지의 매우 높은 카디널리티를 갖는다. 이는 인덱스를 통한 검색에 매우 유리하여, 효율적인 데이터 접근과 빠른 쿼리 응답 시간을 가능하게 한다.
2) 난이도 범위: 브론즈 5부터 루비 1까지 총 30개의 단계를 포함한다.
3) 활성화 여부: True와 False 두 가지 값만을 가지는 낮은 카디널리티를 보입니다. 이 필드는 혼자서는 인덱싱의 효과가 제한적이다.

따라서, '푼 사람 수', '난이도 범위', 그리고 '활성화 여부' 순서로 복합 인덱스를 구성하였다.

![image](https://github.com/user-attachments/assets/af7199c4-7331-47b3-9713-6c2de04b76d4)

**3) 애플리케이션 레벨에서 랜덤으로 문제 추출**
쿼리 내에서 ORDER BY FUNCTION('RAND') 를 사용할 때, 결과 데이터의 크기가 클 경우 무작위로 데이터를 섞는 과정에서 심각한 성능 저하가 발생할 수 있다. 이를 해결하기 위해 페이징을 통해 50개의 데이터를 가져온 후 애플리케이션 레벨에서 랜덤 변수를 적용하여 임의의 데이터를 선택하였다. 이를 통해 데이터베이스의 성능 저하를 방지하였다.

![image](https://github.com/user-attachments/assets/b47ec046-a621-4566-872e-6b7d64729958)

### Result
기존 쿼리의 실행 시간이 79ms에서 18ms로 줄어들어 성능이 크게 개선되었다. 
만약, 5개의 문제를 추출한다면 총 실행 시간이 395ms에서 90ms로 감소한 것이라고 볼 수 있다.

![image](https://github.com/user-attachments/assets/97aea4b9-5763-41cb-b954-9bfc2f8d0f1f)

